### PR TITLE
container: introduce NamedService

### DIFF
--- a/Sources/Container.Arguments.erb
+++ b/Sources/Container.Arguments.erb
@@ -44,6 +44,24 @@ extension Container {
         return _register(serviceType, factory: factory, name: name)
     }
 
+    /// Adds a registration for the specified named service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to register.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and <%= arg_description %> to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, <%= arg_types %>>(
+        namedServiceType: Service.Type,
+        factory: @escaping (Resolver, <%= arg_types %>) -> Service.Service) -> ServiceEntry<Service.Service> where Service: NamedService
+    {
+        return _register(namedServiceType.type, factory: factory, name: namedServiceType.name)
+    }
+
 <% end %>
 }
 
@@ -69,6 +87,21 @@ extension Container {
         <%= arg_param_def %>) -> Service?
     {
         return resolve(serviceType, name: nil, <%= arg_param_name %>: <%= arg_param_call %>)
+    }
+
+    /// Retrieves the instance with the specified named service type and <%= arg_param_description %> to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and <%= arg_param_description %> is found in the `Container`.
+    public func resolve<Service, <%= arg_types %>>(
+        namedServiceType: Service.Type,
+        <%= arg_param_def %>) -> Service.Service? where Service: NamedService
+    {
+        return resolve(namedServiceType.type, name: namedServiceType.name, <%= arg_param_name %>: <%= arg_param_call %>)
     }
 
     /// Retrieves the instance with the specified service type, <%= arg_param_description %> to the factory closure and registration name.

--- a/Sources/Container.Arguments.swift
+++ b/Sources/Container.Arguments.swift
@@ -1,5 +1,9 @@
 //
-//  Copyright © 2019 Swinject Contributors. All rights reserved.
+//  Container.Arguments.swift
+//  Swinject
+//
+//  Created by Yoichi Tagaya on 8/18/15.
+//  Copyright © 2015 Swinject Contributors. All rights reserved.
 //
 
 //
@@ -10,10 +14,10 @@
 // Instead, modify Container.Arguments.erb and run `script/gencode` at the project root directory to generate the code.
 //
 
+
 import Foundation
 
 // MARK: - Registeration with Arguments
-
 extension Container {
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
     ///
@@ -31,9 +35,27 @@ extension Container {
     public func register<Service, Arg1>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1) -> Service
-    ) -> ServiceEntry<Service> {
+        factory: @escaping (Resolver, Arg1) -> Service) -> ServiceEntry<Service>
+    {
         return _register(serviceType, factory: factory, name: name)
+    }
+
+    /// Adds a registration for the specified named service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to register.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 1 argument to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1>(
+        namedServiceType: Service.Type,
+        factory: @escaping (Resolver, Arg1) -> Service.Service) -> ServiceEntry<Service.Service> where Service: NamedService
+    {
+        return _register(namedServiceType.type, factory: factory, name: namedServiceType.name)
     }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
@@ -52,9 +74,27 @@ extension Container {
     public func register<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1, Arg2) -> Service
-    ) -> ServiceEntry<Service> {
+        factory: @escaping (Resolver, Arg1, Arg2) -> Service) -> ServiceEntry<Service>
+    {
         return _register(serviceType, factory: factory, name: name)
+    }
+
+    /// Adds a registration for the specified named service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to register.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 2 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2>(
+        namedServiceType: Service.Type,
+        factory: @escaping (Resolver, Arg1, Arg2) -> Service.Service) -> ServiceEntry<Service.Service> where Service: NamedService
+    {
+        return _register(namedServiceType.type, factory: factory, name: namedServiceType.name)
     }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
@@ -73,9 +113,27 @@ extension Container {
     public func register<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1, Arg2, Arg3) -> Service
-    ) -> ServiceEntry<Service> {
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3) -> Service) -> ServiceEntry<Service>
+    {
         return _register(serviceType, factory: factory, name: name)
+    }
+
+    /// Adds a registration for the specified named service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to register.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 3 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3>(
+        namedServiceType: Service.Type,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3) -> Service.Service) -> ServiceEntry<Service.Service> where Service: NamedService
+    {
+        return _register(namedServiceType.type, factory: factory, name: namedServiceType.name)
     }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
@@ -94,9 +152,27 @@ extension Container {
     public func register<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4) -> Service
-    ) -> ServiceEntry<Service> {
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4) -> Service) -> ServiceEntry<Service>
+    {
         return _register(serviceType, factory: factory, name: name)
+    }
+
+    /// Adds a registration for the specified named service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to register.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 4 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4>(
+        namedServiceType: Service.Type,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4) -> Service.Service) -> ServiceEntry<Service.Service> where Service: NamedService
+    {
+        return _register(namedServiceType.type, factory: factory, name: namedServiceType.name)
     }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
@@ -115,9 +191,27 @@ extension Container {
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service
-    ) -> ServiceEntry<Service> {
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service) -> ServiceEntry<Service>
+    {
         return _register(serviceType, factory: factory, name: name)
+    }
+
+    /// Adds a registration for the specified named service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to register.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 5 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
+        namedServiceType: Service.Type,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5) -> Service.Service) -> ServiceEntry<Service.Service> where Service: NamedService
+    {
+        return _register(namedServiceType.type, factory: factory, name: namedServiceType.name)
     }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
@@ -136,9 +230,27 @@ extension Container {
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service
-    ) -> ServiceEntry<Service> {
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service) -> ServiceEntry<Service>
+    {
         return _register(serviceType, factory: factory, name: name)
+    }
+
+    /// Adds a registration for the specified named service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to register.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 6 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+        namedServiceType: Service.Type,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> Service.Service) -> ServiceEntry<Service.Service> where Service: NamedService
+    {
+        return _register(namedServiceType.type, factory: factory, name: namedServiceType.name)
     }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
@@ -157,9 +269,27 @@ extension Container {
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service
-    ) -> ServiceEntry<Service> {
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service) -> ServiceEntry<Service>
+    {
         return _register(serviceType, factory: factory, name: name)
+    }
+
+    /// Adds a registration for the specified named service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to register.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 7 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+        namedServiceType: Service.Type,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> Service.Service) -> ServiceEntry<Service.Service> where Service: NamedService
+    {
+        return _register(namedServiceType.type, factory: factory, name: namedServiceType.name)
     }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
@@ -178,9 +308,27 @@ extension Container {
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service
-    ) -> ServiceEntry<Service> {
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service) -> ServiceEntry<Service>
+    {
         return _register(serviceType, factory: factory, name: name)
+    }
+
+    /// Adds a registration for the specified named service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to register.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 8 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+        namedServiceType: Service.Type,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) -> Service.Service) -> ServiceEntry<Service.Service> where Service: NamedService
+    {
+        return _register(namedServiceType.type, factory: factory, name: namedServiceType.name)
     }
 
     /// Adds a registration for the specified service with the factory closure to specify how the service is resolved with dependencies.
@@ -199,14 +347,32 @@ extension Container {
     public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
         name: String? = nil,
-        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service
-    ) -> ServiceEntry<Service> {
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service) -> ServiceEntry<Service>
+    {
         return _register(serviceType, factory: factory, name: name)
     }
+
+    /// Adds a registration for the specified named service with the factory closure to specify how the service is resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to register.
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` instance and 9 arguments to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+        namedServiceType: Service.Type,
+        factory: @escaping (Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) -> Service.Service) -> ServiceEntry<Service.Service> where Service: NamedService
+    {
+        return _register(namedServiceType.type, factory: factory, name: namedServiceType.name)
+    }
+
 }
 
 // MARK: - Resolver with Arguments
-
 extension Container {
     /// Retrieves the instance with the specified service type and 1 argument to the factory closure.
     ///
@@ -218,9 +384,24 @@ extension Container {
     ///            and 1 argument is found in the `Container`.
     public func resolve<Service, Arg1>(
         _ serviceType: Service.Type,
-        argument: Arg1
-    ) -> Service? {
+        argument: Arg1) -> Service?
+    {
         return resolve(serviceType, name: nil, argument: argument)
+    }
+
+    /// Retrieves the instance with the specified named service type and 1 argument to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - argument:   1 argument to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and 1 argument is found in the `Container`.
+    public func resolve<Service, Arg1>(
+        namedServiceType: Service.Type,
+        argument: Arg1) -> Service.Service? where Service: NamedService
+    {
+        return resolve(namedServiceType.type, name: namedServiceType.name, argument: argument)
     }
 
     /// Retrieves the instance with the specified service type, 1 argument to the factory closure and registration name.
@@ -233,10 +414,10 @@ extension Container {
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            1 argument and name is found in the `Container`.
     public func resolve<Service, Arg1>(
-        _: Service.Type,
+        _ serviceType: Service.Type,
         name: String?,
-        argument: Arg1
-    ) -> Service? {
+        argument: Arg1) -> Service?
+    {
         typealias FactoryType = ((Resolver, Arg1)) -> Any
         return _resolve(name: name) { (factory: FactoryType) in factory((self, argument)) }
     }
@@ -251,9 +432,24 @@ extension Container {
     ///            and list of 2 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2) -> Service?
+    {
         return resolve(serviceType, name: nil, arguments: arg1, arg2)
+    }
+
+    /// Retrieves the instance with the specified named service type and list of 2 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - arguments:   List of 2 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and list of 2 arguments is found in the `Container`.
+    public func resolve<Service, Arg1, Arg2>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2) -> Service.Service? where Service: NamedService
+    {
+        return resolve(namedServiceType.type, name: namedServiceType.name, arguments: arg1, arg2)
     }
 
     /// Retrieves the instance with the specified service type, list of 2 arguments to the factory closure and registration name.
@@ -266,10 +462,10 @@ extension Container {
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            list of 2 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2>(
-        _: Service.Type,
+        _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2) -> Service?
+    {
         typealias FactoryType = ((Resolver, Arg1, Arg2)) -> Any
         return _resolve(name: name) { (factory: FactoryType) in factory((self, arg1, arg2)) }
     }
@@ -284,9 +480,24 @@ extension Container {
     ///            and list of 3 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
+    {
         return resolve(serviceType, name: nil, arguments: arg1, arg2, arg3)
+    }
+
+    /// Retrieves the instance with the specified named service type and list of 3 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - arguments:   List of 3 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and list of 3 arguments is found in the `Container`.
+    public func resolve<Service, Arg1, Arg2, Arg3>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service.Service? where Service: NamedService
+    {
+        return resolve(namedServiceType.type, name: namedServiceType.name, arguments: arg1, arg2, arg3)
     }
 
     /// Retrieves the instance with the specified service type, list of 3 arguments to the factory closure and registration name.
@@ -299,10 +510,10 @@ extension Container {
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            list of 3 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3>(
-        _: Service.Type,
+        _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
+    {
         typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3)) -> Any
         return _resolve(name: name) { (factory: FactoryType) in factory((self, arg1, arg2, arg3)) }
     }
@@ -317,9 +528,24 @@ extension Container {
     ///            and list of 4 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
+    {
         return resolve(serviceType, name: nil, arguments: arg1, arg2, arg3, arg4)
+    }
+
+    /// Retrieves the instance with the specified named service type and list of 4 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - arguments:   List of 4 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and list of 4 arguments is found in the `Container`.
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service.Service? where Service: NamedService
+    {
+        return resolve(namedServiceType.type, name: namedServiceType.name, arguments: arg1, arg2, arg3, arg4)
     }
 
     /// Retrieves the instance with the specified service type, list of 4 arguments to the factory closure and registration name.
@@ -332,10 +558,10 @@ extension Container {
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            list of 4 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
-        _: Service.Type,
+        _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
+    {
         typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4)) -> Any
         return _resolve(name: name) { (factory: FactoryType) in factory((self, arg1, arg2, arg3, arg4)) }
     }
@@ -350,9 +576,24 @@ extension Container {
     ///            and list of 5 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
+    {
         return resolve(serviceType, name: nil, arguments: arg1, arg2, arg3, arg4, arg5)
+    }
+
+    /// Retrieves the instance with the specified named service type and list of 5 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - arguments:   List of 5 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and list of 5 arguments is found in the `Container`.
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service.Service? where Service: NamedService
+    {
+        return resolve(namedServiceType.type, name: namedServiceType.name, arguments: arg1, arg2, arg3, arg4, arg5)
     }
 
     /// Retrieves the instance with the specified service type, list of 5 arguments to the factory closure and registration name.
@@ -365,10 +606,10 @@ extension Container {
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            list of 5 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
-        _: Service.Type,
+        _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
+    {
         typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4, Arg5)) -> Any
         return _resolve(name: name) { (factory: FactoryType) in factory((self, arg1, arg2, arg3, arg4, arg5)) }
     }
@@ -383,9 +624,24 @@ extension Container {
     ///            and list of 6 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
+    {
         return resolve(serviceType, name: nil, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
+    }
+
+    /// Retrieves the instance with the specified named service type and list of 6 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - arguments:   List of 6 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and list of 6 arguments is found in the `Container`.
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service.Service? where Service: NamedService
+    {
+        return resolve(namedServiceType.type, name: namedServiceType.name, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
     }
 
     /// Retrieves the instance with the specified service type, list of 6 arguments to the factory closure and registration name.
@@ -398,10 +654,10 @@ extension Container {
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            list of 6 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
-        _: Service.Type,
+        _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
+    {
         typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)) -> Any
         return _resolve(name: name) { (factory: FactoryType) in factory((self, arg1, arg2, arg3, arg4, arg5, arg6)) }
     }
@@ -416,9 +672,24 @@ extension Container {
     ///            and list of 7 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
+    {
         return resolve(serviceType, name: nil, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+    }
+
+    /// Retrieves the instance with the specified named service type and list of 7 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - arguments:   List of 7 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and list of 7 arguments is found in the `Container`.
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service.Service? where Service: NamedService
+    {
+        return resolve(namedServiceType.type, name: namedServiceType.name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7)
     }
 
     /// Retrieves the instance with the specified service type, list of 7 arguments to the factory closure and registration name.
@@ -431,10 +702,10 @@ extension Container {
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            list of 7 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
-        _: Service.Type,
+        _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
+    {
         typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)) -> Any
         return _resolve(name: name) { (factory: FactoryType) in factory((self, arg1, arg2, arg3, arg4, arg5, arg6, arg7)) }
     }
@@ -449,9 +720,24 @@ extension Container {
     ///            and list of 8 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
+    {
         return resolve(serviceType, name: nil, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+    }
+
+    /// Retrieves the instance with the specified named service type and list of 8 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - arguments:   List of 8 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and list of 8 arguments is found in the `Container`.
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service.Service? where Service: NamedService
+    {
+        return resolve(namedServiceType.type, name: namedServiceType.name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
     }
 
     /// Retrieves the instance with the specified service type, list of 8 arguments to the factory closure and registration name.
@@ -464,10 +750,10 @@ extension Container {
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            list of 8 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
-        _: Service.Type,
+        _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
+    {
         typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)) -> Any
         return _resolve(name: name) { (factory: FactoryType) in factory((self, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)) }
     }
@@ -482,9 +768,24 @@ extension Container {
     ///            and list of 9 arguments is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
+    {
         return resolve(serviceType, name: nil, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    }
+
+    /// Retrieves the instance with the specified named service type and list of 9 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - arguments:   List of 9 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and list of 9 arguments is found in the `Container`.
+    public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service.Service? where Service: NamedService
+    {
+        return resolve(namedServiceType.type, name: namedServiceType.name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
     }
 
     /// Retrieves the instance with the specified service type, list of 9 arguments to the factory closure and registration name.
@@ -497,11 +798,12 @@ extension Container {
     /// - Returns: The resolved service type instance, or nil if no registration for the service type,
     ///            list of 9 arguments and name is found in the `Container`.
     public func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
-        _: Service.Type,
+        _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
+    {
         typealias FactoryType = ((Resolver, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)) -> Any
         return _resolve(name: name) { (factory: FactoryType) in factory((self, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)) }
     }
+
 }

--- a/Sources/Container.swift
+++ b/Sources/Container.swift
@@ -115,6 +115,25 @@ public final class Container {
         return _register(serviceType, factory: factory, name: name)
     }
 
+    /// Adds a registration for the specified named service with the factory closure to specify how the service is
+    /// resolved with dependencies.
+    ///
+    /// - Parameters:
+    ///   - namedService: The named service to register
+    ///   - factory:     The closure to specify how the service type is resolved with the dependencies of the type.
+    ///                  It is invoked when the `Container` needs to instantiate the instance.
+    ///                  It takes a `Resolver` to inject dependencies to the instance,
+    ///                  and returns the instance of the component type for the service.
+    ///
+    /// - Returns: A registered `ServiceEntry` to configure more settings with method chaining.
+    @discardableResult
+    public func register<Service>(
+        namedServiceType: Service.Type,
+        factory: @escaping (Resolver) -> Service.Service
+    ) -> ServiceEntry<Service.Service> where Service: NamedService {
+        return _register(namedServiceType.type, factory: factory, name: namedServiceType.name)
+    }
+
     /// This method is designed for the use to extend Swinject functionality.
     /// Do NOT use this method unless you intend to write an extension or plugin to Swinject framework.
     ///
@@ -281,6 +300,17 @@ extension Container: Resolver {
     ///            is found in the `Container`.
     public func resolve<Service>(_: Service.Type, name: String?) -> Service? {
         return _resolve(name: name) { (factory: (Resolver) -> Any) in factory(self) }
+    }
+
+    /// Retrieves the instance with the specified named service type and registration name.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            is found in the `Container`.
+    public func resolve<Service>(namedServiceType: Service.Type) -> Service.Service? where Service: NamedService {
+        return _resolve(name: namedServiceType.name) { (factory: (Resolver) -> Any) in factory(self) }
     }
 
     fileprivate func getEntry(for key: ServiceKey) -> ServiceEntryProtocol? {

--- a/Sources/NamedService.swift
+++ b/Sources/NamedService.swift
@@ -1,0 +1,20 @@
+//
+//  Copyright © 2020 Swinject Contributors. All rights reserved.
+//
+
+public protocol NamedService {
+    associatedtype Service
+
+    static var type: Service.Type { get }
+    static var name: String { get }
+}
+
+public extension NamedService {
+    static var type: Service.Type {
+        Service.self
+    }
+
+    static var name: String {
+        "\(self)"
+    }
+}

--- a/Sources/Resolver+NamedService.swift
+++ b/Sources/Resolver+NamedService.swift
@@ -1,0 +1,14 @@
+//
+//  Copyright © 2020 Swinject Contributors. All rights reserved.
+//
+
+public extension Resolver {
+    func resolve<Service>(namedServiceType: Service.Type) -> Service.Service? where Service: NamedService {
+        self.resolve(namedServiceType.type, name: namedServiceType.name)
+    }
+
+    func resolve<Service, Arg0>(namedServiceType: Service.Type,
+                                argument: Arg0) -> Service.Service? where Service: NamedService {
+        self.resolve(namedServiceType.type, name: namedServiceType.name, argument: argument)
+    }
+}

--- a/Sources/Resolver.erb
+++ b/Sources/Resolver.erb
@@ -33,6 +33,14 @@ public protocol Resolver {
     /// - Returns: The resolved service type instance, or nil if no service with the name is found.
     func resolve<Service>(_ serviceType: Service.Type, name: String?) -> Service?
 
+    /// Retrieves the instance with the specified named service type.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no service with the name is found.
+    func resolve<Service>(namedServiceType: Service.Type) -> Service.Service? where Service: NamedService
+
 <% (1..arg_count).each do |i| %>
 <%   arg_types = (1..i).map { |n| "Arg#{n}" }.join(", ") %>
 <%   arg_param = i == 1 ? "argument: Arg1" : "arguments arg1: Arg1, " + (2..i).map{ |n| "_ arg#{n}: Arg#{n}" }.join(", ") %>
@@ -63,6 +71,18 @@ public protocol Resolver {
         _ serviceType: Service.Type,
         name: String?,
         <%= arg_param %>) -> Service?
+
+    /// Retrieves the instance with the specified named service type and <%= arg_param_description %> to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - <%= arg_param_name %>:   <%= arg_param_description.capitalize %> to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and <%= arg_param_description %> is found in the `Container`.
+    func resolve<Service, <%= arg_types %>>(
+        namedServiceType: Service.Type,
+        <%= arg_param %>) -> Service.Service? where Service: NamedService
 
 <% end %>
 

--- a/Sources/Resolver.swift
+++ b/Sources/Resolver.swift
@@ -1,14 +1,19 @@
 //
-//  Copyright © 2019 Swinject Contributors. All rights reserved.
+//  Resolver.swift
+//  Swinject
+//
+//  Created by Yoichi Tagaya on 8/18/15.
+//  Copyright (c) 2015 Swinject Contributors. All rights reserved.
 //
 
 //
 // NOTICE:
 //
 // Resolver.swift is generated from Resolver.erb by ERB.
-// Do NOT modify Resolver.swift directly.
+// Do NOT modify Container.Arguments.swift directly.
 // Instead, modify Resolver.erb and run `script/gencode` at the project root directory to generate the code.
 //
+
 
 public protocol Resolver {
     /// Retrieves the instance with the specified service type.
@@ -27,6 +32,14 @@ public protocol Resolver {
     /// - Returns: The resolved service type instance, or nil if no service with the name is found.
     func resolve<Service>(_ serviceType: Service.Type, name: String?) -> Service?
 
+    /// Retrieves the instance with the specified named service type.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///
+    /// - Returns: The resolved service type instance, or nil if no service with the name is found.
+    func resolve<Service>(namedServiceType: Service.Type) -> Service.Service? where Service: NamedService
+
     /// Retrieves the instance with the specified service type and 1 argument to the factory closure.
     ///
     /// - Parameters:
@@ -37,8 +50,7 @@ public protocol Resolver {
     ///            and 1 argument is found.
     func resolve<Service, Arg1>(
         _ serviceType: Service.Type,
-        argument: Arg1
-    ) -> Service?
+        argument: Arg1) -> Service?
 
     /// Retrieves the instance with the specified service type, 1 argument to the factory closure and registration name.
     ///
@@ -52,8 +64,19 @@ public protocol Resolver {
     func resolve<Service, Arg1>(
         _ serviceType: Service.Type,
         name: String?,
-        argument: Arg1
-    ) -> Service?
+        argument: Arg1) -> Service?
+
+    /// Retrieves the instance with the specified named service type and 1 argument to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - argument:   1 argument to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and 1 argument is found in the `Container`.
+    func resolve<Service, Arg1>(
+        namedServiceType: Service.Type,
+        argument: Arg1) -> Service.Service? where Service: NamedService
 
     /// Retrieves the instance with the specified service type and list of 2 arguments to the factory closure.
     ///
@@ -65,8 +88,7 @@ public protocol Resolver {
     ///            and list of 2 arguments is found.
     func resolve<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2
-    ) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2) -> Service?
 
     /// Retrieves the instance with the specified service type, list of 2 arguments to the factory closure and registration name.
     ///
@@ -80,8 +102,19 @@ public protocol Resolver {
     func resolve<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2
-    ) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2) -> Service?
+
+    /// Retrieves the instance with the specified named service type and list of 2 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - arguments:   List of 2 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and list of 2 arguments is found in the `Container`.
+    func resolve<Service, Arg1, Arg2>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2) -> Service.Service? where Service: NamedService
 
     /// Retrieves the instance with the specified service type and list of 3 arguments to the factory closure.
     ///
@@ -93,8 +126,7 @@ public protocol Resolver {
     ///            and list of 3 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3
-    ) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
 
     /// Retrieves the instance with the specified service type, list of 3 arguments to the factory closure and registration name.
     ///
@@ -108,8 +140,19 @@ public protocol Resolver {
     func resolve<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3
-    ) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
+
+    /// Retrieves the instance with the specified named service type and list of 3 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - arguments:   List of 3 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and list of 3 arguments is found in the `Container`.
+    func resolve<Service, Arg1, Arg2, Arg3>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service.Service? where Service: NamedService
 
     /// Retrieves the instance with the specified service type and list of 4 arguments to the factory closure.
     ///
@@ -121,8 +164,7 @@ public protocol Resolver {
     ///            and list of 4 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4
-    ) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
 
     /// Retrieves the instance with the specified service type, list of 4 arguments to the factory closure and registration name.
     ///
@@ -136,8 +178,19 @@ public protocol Resolver {
     func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4
-    ) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
+
+    /// Retrieves the instance with the specified named service type and list of 4 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - arguments:   List of 4 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and list of 4 arguments is found in the `Container`.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service.Service? where Service: NamedService
 
     /// Retrieves the instance with the specified service type and list of 5 arguments to the factory closure.
     ///
@@ -149,8 +202,7 @@ public protocol Resolver {
     ///            and list of 5 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5
-    ) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
 
     /// Retrieves the instance with the specified service type, list of 5 arguments to the factory closure and registration name.
     ///
@@ -164,8 +216,19 @@ public protocol Resolver {
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5
-    ) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
+
+    /// Retrieves the instance with the specified named service type and list of 5 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - arguments:   List of 5 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and list of 5 arguments is found in the `Container`.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service.Service? where Service: NamedService
 
     /// Retrieves the instance with the specified service type and list of 6 arguments to the factory closure.
     ///
@@ -177,8 +240,7 @@ public protocol Resolver {
     ///            and list of 6 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6
-    ) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
 
     /// Retrieves the instance with the specified service type, list of 6 arguments to the factory closure and registration name.
     ///
@@ -192,8 +254,19 @@ public protocol Resolver {
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6
-    ) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
+
+    /// Retrieves the instance with the specified named service type and list of 6 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - arguments:   List of 6 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and list of 6 arguments is found in the `Container`.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service.Service? where Service: NamedService
 
     /// Retrieves the instance with the specified service type and list of 7 arguments to the factory closure.
     ///
@@ -205,8 +278,7 @@ public protocol Resolver {
     ///            and list of 7 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7
-    ) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
 
     /// Retrieves the instance with the specified service type, list of 7 arguments to the factory closure and registration name.
     ///
@@ -220,8 +292,19 @@ public protocol Resolver {
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7
-    ) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
+
+    /// Retrieves the instance with the specified named service type and list of 7 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - arguments:   List of 7 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and list of 7 arguments is found in the `Container`.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service.Service? where Service: NamedService
 
     /// Retrieves the instance with the specified service type and list of 8 arguments to the factory closure.
     ///
@@ -233,8 +316,7 @@ public protocol Resolver {
     ///            and list of 8 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8
-    ) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
 
     /// Retrieves the instance with the specified service type, list of 8 arguments to the factory closure and registration name.
     ///
@@ -248,8 +330,19 @@ public protocol Resolver {
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8
-    ) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
+
+    /// Retrieves the instance with the specified named service type and list of 8 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - arguments:   List of 8 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and list of 8 arguments is found in the `Container`.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service.Service? where Service: NamedService
 
     /// Retrieves the instance with the specified service type and list of 9 arguments to the factory closure.
     ///
@@ -261,8 +354,7 @@ public protocol Resolver {
     ///            and list of 9 arguments is found.
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9
-    ) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
 
     /// Retrieves the instance with the specified service type, list of 9 arguments to the factory closure and registration name.
     ///
@@ -276,6 +368,19 @@ public protocol Resolver {
     func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9
-    ) -> Service?
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
+
+    /// Retrieves the instance with the specified named service type and list of 9 arguments to the factory closure.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The named service type to resolve.
+    ///   - arguments:   List of 9 arguments to pass to the factory closure.
+    ///
+    /// - Returns: The resolved named service type instance, or nil if no registration for the service type
+    ///            and list of 9 arguments is found in the `Container`.
+    func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service.Service? where Service: NamedService
+
+
 }

--- a/Sources/ServiceEntry.TypeForwarding.swift
+++ b/Sources/ServiceEntry.TypeForwarding.swift
@@ -1,5 +1,9 @@
 //
-//  Copyright © 2019 Swinject Contributors. All rights reserved.
+//  ServiceEntry.TypeForwarding.swift
+//  Swinject-iOS
+//
+//  Created by Jakub Vaňo on 16/02/2018.
+//  Copyright © 2018 Swinject Contributors. All rights reserved.
 //
 
 //
@@ -9,6 +13,7 @@
 // Do NOT modify ServiceEntry.TypeForwarding.swift directly.
 // Instead, modify ServiceEntry.TypeForwarding.erb and run `script/gencode` at the project root directory to generate the code.
 //
+
 
 extension ServiceEntry {
     /// Adds another type which should be resolved using this ServiceEntry - i.e. using the same object scope,
@@ -30,9 +35,9 @@ extension ServiceEntry {
     ///     - types: List of 2 types resolution of which should be forwarded
     @discardableResult
     public func implements<T1, T2>(_ type1: T1.Type, _ type2: T2.Type) -> ServiceEntry<Service> {
-        return implements(type1).implements(type2)
+        return self.implements(type1).implements(type2)        
     }
-
+    
     /// Adds multiple types which should be resolved using this ServiceEntry - i.e. using the same object scope,
     /// arguments and `initCompleted` closures
     ///
@@ -40,9 +45,9 @@ extension ServiceEntry {
     ///     - types: List of 3 types resolution of which should be forwarded
     @discardableResult
     public func implements<T1, T2, T3>(_ type1: T1.Type, _ type2: T2.Type, _ type3: T3.Type) -> ServiceEntry<Service> {
-        return implements(type1).implements(type2).implements(type3)
+        return self.implements(type1).implements(type2).implements(type3)        
     }
-
+    
     /// Adds multiple types which should be resolved using this ServiceEntry - i.e. using the same object scope,
     /// arguments and `initCompleted` closures
     ///
@@ -50,9 +55,9 @@ extension ServiceEntry {
     ///     - types: List of 4 types resolution of which should be forwarded
     @discardableResult
     public func implements<T1, T2, T3, T4>(_ type1: T1.Type, _ type2: T2.Type, _ type3: T3.Type, _ type4: T4.Type) -> ServiceEntry<Service> {
-        return implements(type1).implements(type2).implements(type3).implements(type4)
+        return self.implements(type1).implements(type2).implements(type3).implements(type4)        
     }
-
+    
     /// Adds multiple types which should be resolved using this ServiceEntry - i.e. using the same object scope,
     /// arguments and `initCompleted` closures
     ///
@@ -60,9 +65,9 @@ extension ServiceEntry {
     ///     - types: List of 5 types resolution of which should be forwarded
     @discardableResult
     public func implements<T1, T2, T3, T4, T5>(_ type1: T1.Type, _ type2: T2.Type, _ type3: T3.Type, _ type4: T4.Type, _ type5: T5.Type) -> ServiceEntry<Service> {
-        return implements(type1).implements(type2).implements(type3).implements(type4).implements(type5)
+        return self.implements(type1).implements(type2).implements(type3).implements(type4).implements(type5)        
     }
-
+    
     /// Adds multiple types which should be resolved using this ServiceEntry - i.e. using the same object scope,
     /// arguments and `initCompleted` closures
     ///
@@ -70,9 +75,9 @@ extension ServiceEntry {
     ///     - types: List of 6 types resolution of which should be forwarded
     @discardableResult
     public func implements<T1, T2, T3, T4, T5, T6>(_ type1: T1.Type, _ type2: T2.Type, _ type3: T3.Type, _ type4: T4.Type, _ type5: T5.Type, _ type6: T6.Type) -> ServiceEntry<Service> {
-        return implements(type1).implements(type2).implements(type3).implements(type4).implements(type5).implements(type6)
+        return self.implements(type1).implements(type2).implements(type3).implements(type4).implements(type5).implements(type6)        
     }
-
+    
     /// Adds multiple types which should be resolved using this ServiceEntry - i.e. using the same object scope,
     /// arguments and `initCompleted` closures
     ///
@@ -80,9 +85,9 @@ extension ServiceEntry {
     ///     - types: List of 7 types resolution of which should be forwarded
     @discardableResult
     public func implements<T1, T2, T3, T4, T5, T6, T7>(_ type1: T1.Type, _ type2: T2.Type, _ type3: T3.Type, _ type4: T4.Type, _ type5: T5.Type, _ type6: T6.Type, _ type7: T7.Type) -> ServiceEntry<Service> {
-        return implements(type1).implements(type2).implements(type3).implements(type4).implements(type5).implements(type6).implements(type7)
+        return self.implements(type1).implements(type2).implements(type3).implements(type4).implements(type5).implements(type6).implements(type7)        
     }
-
+    
     /// Adds multiple types which should be resolved using this ServiceEntry - i.e. using the same object scope,
     /// arguments and `initCompleted` closures
     ///
@@ -90,9 +95,9 @@ extension ServiceEntry {
     ///     - types: List of 8 types resolution of which should be forwarded
     @discardableResult
     public func implements<T1, T2, T3, T4, T5, T6, T7, T8>(_ type1: T1.Type, _ type2: T2.Type, _ type3: T3.Type, _ type4: T4.Type, _ type5: T5.Type, _ type6: T6.Type, _ type7: T7.Type, _ type8: T8.Type) -> ServiceEntry<Service> {
-        return implements(type1).implements(type2).implements(type3).implements(type4).implements(type5).implements(type6).implements(type7).implements(type8)
+        return self.implements(type1).implements(type2).implements(type3).implements(type4).implements(type5).implements(type6).implements(type7).implements(type8)        
     }
-
+    
     /// Adds multiple types which should be resolved using this ServiceEntry - i.e. using the same object scope,
     /// arguments and `initCompleted` closures
     ///
@@ -100,6 +105,7 @@ extension ServiceEntry {
     ///     - types: List of 9 types resolution of which should be forwarded
     @discardableResult
     public func implements<T1, T2, T3, T4, T5, T6, T7, T8, T9>(_ type1: T1.Type, _ type2: T2.Type, _ type3: T3.Type, _ type4: T4.Type, _ type5: T5.Type, _ type6: T6.Type, _ type7: T7.Type, _ type8: T8.Type, _ type9: T9.Type) -> ServiceEntry<Service> {
-        return implements(type1).implements(type2).implements(type3).implements(type4).implements(type5).implements(type6).implements(type7).implements(type8).implements(type9)
+        return self.implements(type1).implements(type2).implements(type3).implements(type4).implements(type5).implements(type6).implements(type7).implements(type8).implements(type9)        
     }
+    
 }

--- a/Sources/SynchronizedResolver.Arguments.erb
+++ b/Sources/SynchronizedResolver.Arguments.erb
@@ -42,5 +42,14 @@ extension SynchronizedResolver {
         }
     }
 
+    internal func resolve<Service, <%= arg_types %>>(
+        namedServiceType: Service.Type,
+        <%= arg_param_def %>) -> Service.Service? where Service: NamedService
+    {
+        return container.lock.sync {
+            return self.container.resolve(namedServiceType: namedServiceType, <%= arg_param_name %>: <%= arg_param_call %>)
+        }
+    }
+
 <% end %>
 }

--- a/Sources/SynchronizedResolver.Arguments.swift
+++ b/Sources/SynchronizedResolver.Arguments.swift
@@ -1,5 +1,9 @@
 //
-//  Copyright © 2019 Swinject Contributors. All rights reserved.
+//  SynchronizedResolver.Arguments.swift
+//  Swinject
+//
+//  Created by Yoichi Tagaya on 11/23/15.
+//  Copyright © 2015 Swinject Contributors. All rights reserved.
 //
 
 //
@@ -10,177 +14,259 @@
 // Instead, modify SynchronizedResolver.Arguments.erb and run `script/gencode` at the project root directory to generate the code.
 //
 
-// MARK: - Resolver with Arguments
 
+// MARK: - Resolver with Arguments
 extension SynchronizedResolver {
     internal func resolve<Service, Arg1>(
         _ serviceType: Service.Type,
-        argument: Arg1
-    ) -> Service? {
+        argument: Arg1) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, argument: argument)
+            return self.container.resolve(serviceType, argument: argument)
         }
     }
 
     internal func resolve<Service, Arg1>(
         _ serviceType: Service.Type,
         name: String?,
-        argument: Arg1
-    ) -> Service? {
+        argument: Arg1) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, name: name, argument: argument)
+            return self.container.resolve(serviceType, name: name, argument: argument)
+        }
+    }
+
+    internal func resolve<Service, Arg1>(
+        namedServiceType: Service.Type,
+        argument: Arg1) -> Service.Service? where Service: NamedService
+    {
+        return container.lock.sync {
+            return self.container.resolve(namedServiceType: namedServiceType, argument: argument)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, arguments: arg1, arg2)
+            return self.container.resolve(serviceType, arguments: arg1, arg2)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, name: name, arguments: arg1, arg2)
+            return self.container.resolve(serviceType, name: name, arguments: arg1, arg2)
+        }
+    }
+
+    internal func resolve<Service, Arg1, Arg2>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2) -> Service.Service? where Service: NamedService
+    {
+        return container.lock.sync {
+            return self.container.resolve(namedServiceType: namedServiceType, arguments: arg1, arg2)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, arguments: arg1, arg2, arg3)
+            return self.container.resolve(serviceType, arguments: arg1, arg2, arg3)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3)
+            return self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3)
+        }
+    }
+
+    internal func resolve<Service, Arg1, Arg2, Arg3>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> Service.Service? where Service: NamedService
+    {
+        return container.lock.sync {
+            return self.container.resolve(namedServiceType: namedServiceType, arguments: arg1, arg2, arg3)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4)
+            return self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4)
+            return self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4)
+        }
+    }
+
+    internal func resolve<Service, Arg1, Arg2, Arg3, Arg4>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> Service.Service? where Service: NamedService
+    {
+        return container.lock.sync {
+            return self.container.resolve(namedServiceType: namedServiceType, arguments: arg1, arg2, arg3, arg4)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5)
+            return self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5)
+            return self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5)
+        }
+    }
+
+    internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> Service.Service? where Service: NamedService
+    {
+        return container.lock.sync {
+            return self.container.resolve(namedServiceType: namedServiceType, arguments: arg1, arg2, arg3, arg4, arg5)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
+            return self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
+            return self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
+        }
+    }
+
+    internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> Service.Service? where Service: NamedService
+    {
+        return container.lock.sync {
+            return self.container.resolve(namedServiceType: namedServiceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+            return self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+            return self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+        }
+    }
+
+    internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> Service.Service? where Service: NamedService
+    {
+        return container.lock.sync {
+            return self.container.resolve(namedServiceType: namedServiceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+            return self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+            return self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+        }
+    }
+
+    internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8) -> Service.Service? where Service: NamedService
+    {
+        return container.lock.sync {
+            return self.container.resolve(namedServiceType: namedServiceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+            return self.container.resolve(serviceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
         }
     }
 
     internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
         _ serviceType: Service.Type,
         name: String?,
-        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9
-    ) -> Service? {
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service?
+    {
         return container.lock.sync {
-            self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+            return self.container.resolve(serviceType, name: name, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
         }
     }
+
+    internal func resolve<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(
+        namedServiceType: Service.Type,
+        arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8, _ arg9: Arg9) -> Service.Service? where Service: NamedService
+    {
+        return container.lock.sync {
+            return self.container.resolve(namedServiceType: namedServiceType, arguments: arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+        }
+    }
+
 }

--- a/Sources/SynchronizedResolver.swift
+++ b/Sources/SynchronizedResolver.swift
@@ -35,4 +35,10 @@ extension SynchronizedResolver: Resolver {
             self.container.resolve(serviceType, name: name)
         }
     }
+
+    internal func resolve<Service>(namedServiceType: Service.Type) -> Service.Service? where Service: NamedService {
+        return container.lock.sync {
+            self.container.resolve(namedServiceType: namedServiceType)
+        }
+    }
 }

--- a/Swinject.xcodeproj/project.pbxproj
+++ b/Swinject.xcodeproj/project.pbxproj
@@ -118,7 +118,20 @@
 		706A459CAE24E0D5054CEC30 /* GraphIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B058F48AF289C3AC307C2F7 /* GraphIdentifier.swift */; };
 		725EF35B0CC5E62791D5EA09 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34AFFAC41BA9D02A38BDB7A3 /* Nimble.framework */; };
 		737740CDFB89189DFF5FD165 /* Swinject.h in Headers */ = {isa = PBXBuildFile; fileRef = 74DE57FB3E8228904E6FE0D7 /* Swinject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		741D114024FAF8CC008ABC57 /* Resolver+NamedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741D113F24FAF8CC008ABC57 /* Resolver+NamedService.swift */; };
+		741D114424FAFB3A008ABC57 /* NamedServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741D114124FAF9EC008ABC57 /* NamedServiceSpec.swift */; };
+		741D114524FAFB3A008ABC57 /* NamedServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741D114124FAF9EC008ABC57 /* NamedServiceSpec.swift */; };
+		741D114624FAFB3B008ABC57 /* NamedServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741D114124FAF9EC008ABC57 /* NamedServiceSpec.swift */; };
+		741D114724FAFB3B008ABC57 /* NamedServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741D114124FAF9EC008ABC57 /* NamedServiceSpec.swift */; };
+		741D114824FAFB63008ABC57 /* NamedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748D5AD224EB450B00D1AE32 /* NamedService.swift */; };
+		741D114924FAFB63008ABC57 /* NamedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748D5AD224EB450B00D1AE32 /* NamedService.swift */; };
+		741D114A24FAFB64008ABC57 /* NamedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748D5AD224EB450B00D1AE32 /* NamedService.swift */; };
+		741D114B24FAFB6A008ABC57 /* Resolver+NamedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741D113F24FAF8CC008ABC57 /* Resolver+NamedService.swift */; };
+		741D114C24FAFB6B008ABC57 /* Resolver+NamedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741D113F24FAF8CC008ABC57 /* Resolver+NamedService.swift */; };
+		741D114D24FAFB6B008ABC57 /* Resolver+NamedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741D113F24FAF8CC008ABC57 /* Resolver+NamedService.swift */; };
+		741D114F24FAFCF6008ABC57 /* ContainerSpec.NamedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741D114E24FAFCF6008ABC57 /* ContainerSpec.NamedService.swift */; };
 		744024F52826E2B351B38D58 /* SynchronizedResolver.Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1979933FD5852C28F6D8784A /* SynchronizedResolver.Arguments.swift */; };
+		748D5AD324EB450B00D1AE32 /* NamedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748D5AD224EB450B00D1AE32 /* NamedService.swift */; };
 		75A776D4072BCF74F298D818 /* EmploymentAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077047532310E42432E94D83 /* EmploymentAssembly.swift */; };
 		77BF219EAB4FC8475943CECC /* Swinject.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D434EB4C13CF9D9FA6D80CB /* Swinject.framework */; };
 		77E67A2C566A1DFD5407BBA4 /* Container.Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F839BCDE52371FE49454B9 /* Container.Logging.swift */; };
@@ -344,6 +357,10 @@
 		7101AB0DE88A5340F7EAAC04 /* InstanceWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceWrapper.swift; sourceTree = "<group>"; };
 		710204D1A678B791BB0FC60E /* SynchronizedResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedResolver.swift; sourceTree = "<group>"; };
 		7196841DBEB28245AF90D79E /* ContainerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerSpec.swift; sourceTree = "<group>"; };
+		741D113F24FAF8CC008ABC57 /* Resolver+NamedService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Resolver+NamedService.swift"; sourceTree = "<group>"; };
+		741D114124FAF9EC008ABC57 /* NamedServiceSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NamedServiceSpec.swift; sourceTree = "<group>"; };
+		741D114E24FAFCF6008ABC57 /* ContainerSpec.NamedService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerSpec.NamedService.swift; sourceTree = "<group>"; };
+		748D5AD224EB450B00D1AE32 /* NamedService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamedService.swift; sourceTree = "<group>"; };
 		74A5A3258A20A90BA4C6BBBE /* Pods-Swinject-watchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Swinject-watchOS.release.xcconfig"; path = "Target Support Files/Pods-Swinject-watchOS/Pods-Swinject-watchOS.release.xcconfig"; sourceTree = "<group>"; };
 		74DE57FB3E8228904E6FE0D7 /* Swinject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Swinject.h; sourceTree = "<group>"; };
 		74FE954435F1C361FB14C24B /* ContainerSpec.CustomScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerSpec.CustomScope.swift; sourceTree = "<group>"; };
@@ -478,6 +495,7 @@
 				EB483EF286681035F8A98F43 /* ContainerSpec.CustomStringConvertible.swift */,
 				5DA24DF3EBEAA57BFC8D8631 /* ContainerSpec.DebugHelper.swift */,
 				1524909CA7B5BFA7E2BEE347 /* ContainerSpec.GraphCaching.swift */,
+				741D114E24FAFCF6008ABC57 /* ContainerSpec.NamedService.swift */,
 				7196841DBEB28245AF90D79E /* ContainerSpec.swift */,
 				A8817F361F89EB6F454B8F89 /* ContainerSpec.TypeForwarding.swift */,
 				077047532310E42432E94D83 /* EmploymentAssembly.swift */,
@@ -485,6 +503,7 @@
 				AEAC51C6D09DEBE863D5A06E /* Info.plist */,
 				330AFD602B38E9D09A67B587 /* LazySpec.swift */,
 				2380F40FC2B9229F36B13679 /* LoadAwareAssembly.swift */,
+				741D114124FAF9EC008ABC57 /* NamedServiceSpec.swift */,
 				D7B00D2ED19209D0C6210169 /* Person.swift */,
 				0AF3AB0ED5AFE7A82E85EC5C /* ProviderSpec.swift */,
 				D794CFA41AB11452E4FC6B48 /* ServiceEntrySpec.swift */,
@@ -622,7 +641,9 @@
 				7101AB0DE88A5340F7EAAC04 /* InstanceWrapper.swift */,
 				A79864FE285C06A91E006806 /* ObjectScope.Standard.swift */,
 				957AFDACC07687608E5E5F7E /* ObjectScope.swift */,
+				748D5AD224EB450B00D1AE32 /* NamedService.swift */,
 				EC379E27E9804FC6C0BA0842 /* Resolver.swift */,
+				741D113F24FAF8CC008ABC57 /* Resolver+NamedService.swift */,
 				76238B6105E2E443A94CE595 /* ServiceEntry.swift */,
 				54FFC812F14E9976208B644F /* ServiceEntry.TypeForwarding.swift */,
 				BD2ED5B0128132DCD709777F /* ServiceKey.swift */,
@@ -1103,6 +1124,7 @@
 			files = (
 				602201FE3E6CC64F594DEBA1 /* Assembler.swift in Sources */,
 				A5D9F0A6D8FC89662658FBF3 /* Assembly.swift in Sources */,
+				741D114D24FAFB6B008ABC57 /* Resolver+NamedService.swift in Sources */,
 				FE07C0CCCD45639FBF85A456 /* Behavior.swift in Sources */,
 				9FF7BABC0BA21A89A755E37C /* Container.Arguments.swift in Sources */,
 				363C4230CAC4547E7A676249 /* Container.Logging.swift in Sources */,
@@ -1120,6 +1142,7 @@
 				513BDFB32DCE5B048672C33D /* ServiceEntry.swift in Sources */,
 				A39172D39FE39D24A12A7257 /* ServiceKey.swift in Sources */,
 				2E8EB4C1459E0B1047E08338 /* SpinLock.swift in Sources */,
+				741D114A24FAFB64008ABC57 /* NamedService.swift in Sources */,
 				C9F920F9CEDCD69113D85834 /* SynchronizedResolver.Arguments.swift in Sources */,
 				D0668C3AB5ED89951B60DA2E /* SynchronizedResolver.swift in Sources */,
 				68DA3B5FB308092FE9B5C733 /* UnavailableItems.swift in Sources */,
@@ -1139,6 +1162,7 @@
 				A197085CE442365D732EE6FE /* ContainerSpec.Arguments.swift in Sources */,
 				DCF03B6DB8F99A474F2B575C /* ContainerSpec.Behavior.swift in Sources */,
 				030256DFF226FE93C75833F5 /* ContainerSpec.Circularity.swift in Sources */,
+				741D114F24FAFCF6008ABC57 /* ContainerSpec.NamedService.swift in Sources */,
 				88D3BB9CECA9F373FF882AFB /* ContainerSpec.CustomScope.swift in Sources */,
 				87FB12D90646AFA5AC739B15 /* ContainerSpec.CustomStringConvertible.swift in Sources */,
 				229E0EAD0D8413D4CA67094C /* ContainerSpec.DebugHelper.swift in Sources */,
@@ -1146,6 +1170,7 @@
 				2A207632400E46F722193C7E /* ContainerSpec.TypeForwarding.swift in Sources */,
 				A9E5D5915FE433CD1DCD0022 /* ContainerSpec.swift in Sources */,
 				1276420B3D3ED5ACFC2C5B4F /* EmploymentAssembly.swift in Sources */,
+				741D114524FAFB3A008ABC57 /* NamedServiceSpec.swift in Sources */,
 				0266A3114C82246F18B52860 /* Food.swift in Sources */,
 				5E22405979EC888E46F0CF8D /* LazySpec.swift in Sources */,
 				471EEA7C90D1AEA45CAC0236 /* LoadAwareAssembly.swift in Sources */,
@@ -1177,6 +1202,7 @@
 				2AED444F7141B101091A1464 /* ContainerSpec.TypeForwarding.swift in Sources */,
 				07C2E78624A40118D0316CB6 /* ContainerSpec.swift in Sources */,
 				75A776D4072BCF74F298D818 /* EmploymentAssembly.swift in Sources */,
+				741D114424FAFB3A008ABC57 /* NamedServiceSpec.swift in Sources */,
 				44676A0D0399F323A31E0451 /* Food.swift in Sources */,
 				019AF80A06CA3271456549BE /* LazySpec.swift in Sources */,
 				4D35CD2C4FD5788F087A4D51 /* LoadAwareAssembly.swift in Sources */,
@@ -1208,6 +1234,7 @@
 				BB35F3F717A09AD398FCC67A /* ContainerSpec.TypeForwarding.swift in Sources */,
 				1BD861CA392B1E63D249906B /* ContainerSpec.swift in Sources */,
 				3A41F4B375C1CE29A75F6AE9 /* EmploymentAssembly.swift in Sources */,
+				741D114724FAFB3B008ABC57 /* NamedServiceSpec.swift in Sources */,
 				115515373F266C35E8DBE724 /* Food.swift in Sources */,
 				62BE8825EF3E272428AC3CB5 /* LazySpec.swift in Sources */,
 				BA36EC78ECA2701853CD3E12 /* LoadAwareAssembly.swift in Sources */,
@@ -1239,6 +1266,7 @@
 				4077A7732A2412CBB9E8A759 /* ContainerSpec.TypeForwarding.swift in Sources */,
 				41084A2F24BB4222CCFFAD27 /* ContainerSpec.swift in Sources */,
 				1613AE7671758A85F760C5DF /* EmploymentAssembly.swift in Sources */,
+				741D114624FAFB3B008ABC57 /* NamedServiceSpec.swift in Sources */,
 				4736BF9B29704061B29BFACD /* Food.swift in Sources */,
 				B02AEA6ED72703B0F2FFE7C5 /* LazySpec.swift in Sources */,
 				D210E7349E119368A741DB2F /* LoadAwareAssembly.swift in Sources */,
@@ -1257,6 +1285,7 @@
 			files = (
 				474A4D73269D7BDF0844D704 /* Assembler.swift in Sources */,
 				81AE1BCE31BC99440151A68F /* Assembly.swift in Sources */,
+				741D114C24FAFB6B008ABC57 /* Resolver+NamedService.swift in Sources */,
 				2C838FEC75D618B575750A17 /* Behavior.swift in Sources */,
 				1DB36B1F8919879607F67F35 /* Container.Arguments.swift in Sources */,
 				9D78DAAC0307D9422C501D33 /* Container.Logging.swift in Sources */,
@@ -1274,6 +1303,7 @@
 				1A2759577A52C96E28BB44F0 /* ServiceEntry.swift in Sources */,
 				AEE58DEFB1764391B49E4EA0 /* ServiceKey.swift in Sources */,
 				CC57D5BBD5945E37B704B7B4 /* SpinLock.swift in Sources */,
+				741D114924FAFB63008ABC57 /* NamedService.swift in Sources */,
 				3F48DF31B4FAB90048A44A04 /* SynchronizedResolver.Arguments.swift in Sources */,
 				31FF42AD5DFDB5FD7FAB5530 /* SynchronizedResolver.swift in Sources */,
 				58654C80A0946909D44F6BAD /* UnavailableItems.swift in Sources */,
@@ -1287,6 +1317,7 @@
 			files = (
 				8F8BF2FFD2D666C4EE71E796 /* Assembler.swift in Sources */,
 				695E6FF61B8CD35434685835 /* Assembly.swift in Sources */,
+				741D114B24FAFB6A008ABC57 /* Resolver+NamedService.swift in Sources */,
 				4D667425CB08BF894C1A78AA /* Behavior.swift in Sources */,
 				5BAC0A607F822D6205DA6178 /* Container.Arguments.swift in Sources */,
 				40FCA2AB08F4EA23096075AB /* Container.Logging.swift in Sources */,
@@ -1304,6 +1335,7 @@
 				35C9BCE88B6D6567760D7389 /* ServiceEntry.swift in Sources */,
 				3957BFF436703E5C0434D41E /* ServiceKey.swift in Sources */,
 				4C44517A43BAAFB8E4E99255 /* SpinLock.swift in Sources */,
+				741D114824FAFB63008ABC57 /* NamedService.swift in Sources */,
 				DC0704139B41CA402DF1922A /* SynchronizedResolver.Arguments.swift in Sources */,
 				9CEB151A9DB8675B5AB48432 /* SynchronizedResolver.swift in Sources */,
 				95070453A9934F08F9E02E6C /* UnavailableItems.swift in Sources */,
@@ -1317,6 +1349,7 @@
 			files = (
 				FED7D8B8C74876D03B5D09DE /* Assembler.swift in Sources */,
 				5010597DD8C25E6684C8087E /* Assembly.swift in Sources */,
+				741D114024FAF8CC008ABC57 /* Resolver+NamedService.swift in Sources */,
 				C60108843AA83DF2B408EE87 /* Behavior.swift in Sources */,
 				AD91C0A080A7CE74369407E7 /* Container.Arguments.swift in Sources */,
 				77E67A2C566A1DFD5407BBA4 /* Container.Logging.swift in Sources */,
@@ -1334,6 +1367,7 @@
 				808983B2AF095E481615029E /* ServiceEntry.swift in Sources */,
 				E28F56015BFBB47A791856D3 /* ServiceKey.swift in Sources */,
 				7C87F64B425D439EFB2B9A07 /* SpinLock.swift in Sources */,
+				748D5AD324EB450B00D1AE32 /* NamedService.swift in Sources */,
 				744024F52826E2B351B38D58 /* SynchronizedResolver.Arguments.swift in Sources */,
 				FAEDCCC2810D4FD8A7A7AF8D /* SynchronizedResolver.swift in Sources */,
 				4D631FA98F95F809740D6585 /* UnavailableItems.swift in Sources */,

--- a/Tests/SwinjectTests/ContainerSpec.NamedService.swift
+++ b/Tests/SwinjectTests/ContainerSpec.NamedService.swift
@@ -1,0 +1,584 @@
+//
+//  Copyright © 2020 Swinject Contributors. All rights reserved.
+//
+
+import Nimble
+import Quick
+import Swinject
+
+private enum MockNamedService: NamedService {
+    typealias Service = (String) -> Int
+}
+
+// swiftlint:disable line_length
+// swiftlint:disable file_length
+class ContainerSpec_NamedService: QuickSpec {
+    override func spec() {
+        var container: Container!
+        beforeEach {
+            container = Container()
+        }
+
+        it("resolves the registered NamedService") {
+            let expectedArg = "1701"
+            let expectedResult = 1701
+            var receivedArg: String?
+            var receivedResult: Int?
+
+            // Given: a function to register in a Swinject container
+            let functionToRegister: MockNamedService.Service = { arg in
+                receivedArg = arg
+                return expectedResult
+            }
+
+            // Given: a registration of this function as a NamedService
+            container.register(namedServiceType: MockNamedService.self) { _ -> MockNamedService.Service in
+                return functionToRegister
+            }
+
+            // When: resolving this NamedService
+            let resolvedNamedService = container.resolve(namedServiceType: MockNamedService.self)
+
+            // Then: the NamedService is resolved
+            expect(resolvedNamedService).toNot(beNil())
+
+            // When: executing the resolved function
+            receivedResult = resolvedNamedService!(expectedArg)
+
+            // Then: the resolved function is the one that has been registered
+            expect(receivedArg) == expectedArg
+            expect(receivedResult) == expectedResult
+        }
+
+        it("resolves the registered NamedService with one argument") {
+            let expectedArg = "1701"
+            let expectedResult = 1701
+
+            var receivedArg: String?
+            var receivedResult: Int?
+            let expectedArgInRegister = 17.01
+            var receivedArgInRegister: Double?
+
+            // Given: a function to register in a Swinject container
+            let functionToRegister: MockNamedService.Service = { arg in
+                receivedArg = arg
+                return expectedResult
+            }
+
+            // Given: a registration of this function as a NamedService with a Double parameter
+            container.register(namedServiceType: MockNamedService.self,
+                               factory: { (_, arg: Double) -> MockNamedService.Service in
+                                receivedArgInRegister = arg
+                                return functionToRegister
+            })
+
+            // When: resolving this NamedService
+            let resolvedNamedService = container.resolve(namedServiceType: MockNamedService.self,
+                                                         argument: expectedArgInRegister)
+
+            // Then: the NamedService is resolved
+            expect(resolvedNamedService).toNot(beNil())
+
+            // When: executing the resolved function
+            receivedResult = resolvedNamedService!(expectedArg)
+
+            // Then: the resolved function is the one that has been registered
+            expect(receivedArg) == expectedArg
+            expect(receivedResult) == expectedResult
+            // Then: the parameter received in the register function is the expected one
+            expect(receivedArgInRegister) == expectedArgInRegister
+        }
+
+        it("resolves the registered NamedService with two arguments") {
+            let expectedArg = "1701"
+            let expectedResult = 1701
+
+            var receivedArg: String?
+            var receivedResult: Int?
+            let expectedArgInRegister1 = 17.01
+            var receivedArgInRegister1: Double?
+            let expectedArgInRegister2 = 17.02
+            var receivedArgInRegister2: Double?
+
+            // Given: a function to register in a Swinject container
+            let functionToRegister: MockNamedService.Service = { arg in
+                receivedArg = arg
+                return expectedResult
+            }
+
+            // Given: a registration of this function as a NamedService with some Double parameters
+            container.register(namedServiceType: MockNamedService.self,
+                               factory: { (_, arg1: Double, arg2: Double) -> MockNamedService.Service in
+                                receivedArgInRegister1 = arg1
+                                receivedArgInRegister2 = arg2
+                                return functionToRegister
+            })
+
+            // When: resolving this NamedService
+            let resolvedNamedService = container.resolve(namedServiceType: MockNamedService.self,
+                                                         arguments: expectedArgInRegister1,
+                                                         expectedArgInRegister2)
+
+            // Then: the NamedService is resolved
+            expect(resolvedNamedService).toNot(beNil())
+
+            // When: executing the resolved function
+            receivedResult = resolvedNamedService!(expectedArg)
+
+            // Then: the registered function is called
+            expect(receivedArg) == expectedArg
+            expect(receivedResult) == expectedResult
+            // Then: the parameters received in the register function are the expected one
+            expect(receivedArgInRegister1) == expectedArgInRegister1
+            expect(receivedArgInRegister2) == expectedArgInRegister2
+        }
+
+        it("resolves the registered NamedService with three arguments") {
+            let expectedArg = "1701"
+            let expectedResult = 1701
+
+            var receivedArg: String?
+            var receivedResult: Int?
+            let expectedArgInRegister1 = 17.01
+            var receivedArgInRegister1: Double?
+            let expectedArgInRegister2 = 17.02
+            var receivedArgInRegister2: Double?
+            let expectedArgInRegister3 = 17.03
+            var receivedArgInRegister3: Double?
+
+            // Given: a function to register in a Swinject container
+            let functionToRegister: MockNamedService.Service = { arg in
+                receivedArg = arg
+                return expectedResult
+            }
+
+            // Given: a registration of this function as a NamedService with some Double parameters
+            container.register(namedServiceType: MockNamedService.self,
+                               factory: { (_, arg1: Double, arg2: Double, arg3: Double) -> MockNamedService.Service in
+                                receivedArgInRegister1 = arg1
+                                receivedArgInRegister2 = arg2
+                                receivedArgInRegister3 = arg3
+                                return functionToRegister
+            })
+
+            // When: resolving this NamedService
+            let resolvedNamedService = container.resolve(namedServiceType: MockNamedService.self,
+                                                         arguments: expectedArgInRegister1,
+                                                         expectedArgInRegister2,
+                                                         expectedArgInRegister3)
+
+            // Then: the NamedService is resolved
+            expect(resolvedNamedService).toNot(beNil())
+
+            // When: executing the resolved function
+            receivedResult = resolvedNamedService!(expectedArg)
+
+            // Then: the registered function is called
+            expect(receivedArg) == expectedArg
+            expect(receivedResult) == expectedResult
+            // Then: the parameters received in the register function are the expected one
+            expect(receivedArgInRegister1) == expectedArgInRegister1
+            expect(receivedArgInRegister2) == expectedArgInRegister2
+            expect(receivedArgInRegister3) == expectedArgInRegister3
+        }
+
+        it("resolves the registered NamedService with four arguments") {
+            let expectedArg = "1701"
+            let expectedResult = 1701
+
+            var receivedArg: String?
+            var receivedResult: Int?
+            let expectedArgInRegister1 = 17.01
+            var receivedArgInRegister1: Double?
+            let expectedArgInRegister2 = 17.02
+            var receivedArgInRegister2: Double?
+            let expectedArgInRegister3 = 17.03
+            var receivedArgInRegister3: Double?
+            let expectedArgInRegister4 = 17.04
+            var receivedArgInRegister4: Double?
+
+            // Given: a function to register in a Swinject container
+            let functionToRegister: MockNamedService.Service = { arg in
+                receivedArg = arg
+                return expectedResult
+            }
+
+            // Given: a registration of this function as a NamedService with some Double parameters
+            container.register(namedServiceType: MockNamedService.self,
+                               factory: { (_, arg1: Double, arg2: Double, arg3: Double, arg4: Double) -> MockNamedService.Service in
+                                receivedArgInRegister1 = arg1
+                                receivedArgInRegister2 = arg2
+                                receivedArgInRegister3 = arg3
+                                receivedArgInRegister4 = arg4
+                                return functionToRegister
+            })
+
+            // When: resolving this NamedService
+            let resolvedNamedService = container.resolve(namedServiceType: MockNamedService.self,
+                                                         arguments: expectedArgInRegister1,
+                                                         expectedArgInRegister2,
+                                                         expectedArgInRegister3,
+                                                         expectedArgInRegister4)
+
+            // Then: the NamedService is resolved
+            expect(resolvedNamedService).toNot(beNil())
+
+            // When: executing the resolved function
+            receivedResult = resolvedNamedService!(expectedArg)
+
+            // Then: the registered function is called
+            expect(receivedArg) == expectedArg
+            expect(receivedResult) == expectedResult
+            // Then: the parameters received in the register function are the expected one
+            expect(receivedArgInRegister1) == expectedArgInRegister1
+            expect(receivedArgInRegister2) == expectedArgInRegister2
+            expect(receivedArgInRegister3) == expectedArgInRegister3
+            expect(receivedArgInRegister4) == expectedArgInRegister4
+        }
+
+        it("resolves the registered NamedService with five arguments") {
+            let expectedArg = "1701"
+            let expectedResult = 1701
+
+            var receivedArg: String?
+            var receivedResult: Int?
+            let expectedArgInRegister1 = 17.01
+            var receivedArgInRegister1: Double?
+            let expectedArgInRegister2 = 17.02
+            var receivedArgInRegister2: Double?
+            let expectedArgInRegister3 = 17.03
+            var receivedArgInRegister3: Double?
+            let expectedArgInRegister4 = 17.04
+            var receivedArgInRegister4: Double?
+            let expectedArgInRegister5 = 17.05
+            var receivedArgInRegister5: Double?
+
+            // Given: a function to register in a Swinject container
+            let functionToRegister: MockNamedService.Service = { arg in
+                receivedArg = arg
+                return expectedResult
+            }
+
+            // Given: a registration of this function as a NamedService with some Double parameters
+            container.register(namedServiceType: MockNamedService.self,
+                               factory: { (_, arg1: Double, arg2: Double, arg3: Double, arg4: Double, arg5: Double) -> MockNamedService.Service in
+                                receivedArgInRegister1 = arg1
+                                receivedArgInRegister2 = arg2
+                                receivedArgInRegister3 = arg3
+                                receivedArgInRegister4 = arg4
+                                receivedArgInRegister5 = arg5
+                                return functionToRegister
+            })
+
+            // When: resolving this NamedService
+            let resolvedNamedService = container.resolve(namedServiceType: MockNamedService.self,
+                                                         arguments: expectedArgInRegister1,
+                                                         expectedArgInRegister2,
+                                                         expectedArgInRegister3,
+                                                         expectedArgInRegister4,
+                                                         expectedArgInRegister5)
+
+            // Then: the NamedService is resolved
+            expect(resolvedNamedService).toNot(beNil())
+
+            // When: executing the resolved function
+            receivedResult = resolvedNamedService!(expectedArg)
+
+            // Then: the registered function is called
+            expect(receivedArg) == expectedArg
+            expect(receivedResult) == expectedResult
+            // Then: the parameters received in the register function are the expected one
+            expect(receivedArgInRegister1) == expectedArgInRegister1
+            expect(receivedArgInRegister2) == expectedArgInRegister2
+            expect(receivedArgInRegister3) == expectedArgInRegister3
+            expect(receivedArgInRegister4) == expectedArgInRegister4
+            expect(receivedArgInRegister5) == expectedArgInRegister5
+        }
+
+        it("resolves the registered NamedService with six arguments") {
+            let expectedArg = "1701"
+            let expectedResult = 1701
+
+            var receivedArg: String?
+            var receivedResult: Int?
+            let expectedArgInRegister1 = 17.01
+            var receivedArgInRegister1: Double?
+            let expectedArgInRegister2 = 17.02
+            var receivedArgInRegister2: Double?
+            let expectedArgInRegister3 = 17.03
+            var receivedArgInRegister3: Double?
+            let expectedArgInRegister4 = 17.04
+            var receivedArgInRegister4: Double?
+            let expectedArgInRegister5 = 17.05
+            var receivedArgInRegister5: Double?
+            let expectedArgInRegister6 = 17.06
+            var receivedArgInRegister6: Double?
+
+            // Given: a function to register in a Swinject container
+            let functionToRegister: MockNamedService.Service = { arg in
+                receivedArg = arg
+                return expectedResult
+            }
+
+            // Given: a registration of this function as a NamedService with some Double parameters
+            container.register(namedServiceType: MockNamedService.self,
+                               factory: { (_, arg1: Double, arg2: Double, arg3: Double, arg4: Double, arg5: Double, arg6: Double) -> MockNamedService.Service in
+                                receivedArgInRegister1 = arg1
+                                receivedArgInRegister2 = arg2
+                                receivedArgInRegister3 = arg3
+                                receivedArgInRegister4 = arg4
+                                receivedArgInRegister5 = arg5
+                                receivedArgInRegister6 = arg6
+                                return functionToRegister
+            })
+
+            // When: resolving this NamedService
+            let resolvedNamedService = container.resolve(namedServiceType: MockNamedService.self,
+                                                         arguments: expectedArgInRegister1,
+                                                         expectedArgInRegister2,
+                                                         expectedArgInRegister3,
+                                                         expectedArgInRegister4,
+                                                         expectedArgInRegister5,
+                                                         expectedArgInRegister6)
+
+            // Then: the NamedService is resolved
+            expect(resolvedNamedService).toNot(beNil())
+
+            // When: executing the resolved function
+            receivedResult = resolvedNamedService!(expectedArg)
+
+            // Then: the registered function is called
+            expect(receivedArg) == expectedArg
+            expect(receivedResult) == expectedResult
+            // Then: the parameters received in the register function are the expected one
+            expect(receivedArgInRegister1) == expectedArgInRegister1
+            expect(receivedArgInRegister2) == expectedArgInRegister2
+            expect(receivedArgInRegister3) == expectedArgInRegister3
+            expect(receivedArgInRegister4) == expectedArgInRegister4
+            expect(receivedArgInRegister5) == expectedArgInRegister5
+            expect(receivedArgInRegister6) == expectedArgInRegister6
+        }
+
+        it("resolves the registered NamedService with seven arguments") {
+            let expectedArg = "1701"
+            let expectedResult = 1701
+
+            var receivedArg: String?
+            var receivedResult: Int?
+            let expectedArgInRegister1 = 17.01
+            var receivedArgInRegister1: Double?
+            let expectedArgInRegister2 = 17.02
+            var receivedArgInRegister2: Double?
+            let expectedArgInRegister3 = 17.03
+            var receivedArgInRegister3: Double?
+            let expectedArgInRegister4 = 17.04
+            var receivedArgInRegister4: Double?
+            let expectedArgInRegister5 = 17.05
+            var receivedArgInRegister5: Double?
+            let expectedArgInRegister6 = 17.06
+            var receivedArgInRegister6: Double?
+            let expectedArgInRegister7 = 17.07
+            var receivedArgInRegister7: Double?
+
+            // Given: a function to register in a Swinject container
+            let functionToRegister: MockNamedService.Service = { arg in
+                receivedArg = arg
+                return expectedResult
+            }
+
+            // Given: a registration of this function as a NamedService with some Double parameters
+            container.register(namedServiceType: MockNamedService.self,
+                               factory: { (_, arg1: Double, arg2: Double, arg3: Double, arg4: Double, arg5: Double, arg6: Double, arg7: Double) -> MockNamedService.Service in
+                                receivedArgInRegister1 = arg1
+                                receivedArgInRegister2 = arg2
+                                receivedArgInRegister3 = arg3
+                                receivedArgInRegister4 = arg4
+                                receivedArgInRegister5 = arg5
+                                receivedArgInRegister6 = arg6
+                                receivedArgInRegister7 = arg7
+                                return functionToRegister
+            })
+
+            // When: resolving this NamedService
+            let resolvedNamedService = container.resolve(namedServiceType: MockNamedService.self,
+                                                         arguments: expectedArgInRegister1,
+                                                         expectedArgInRegister2,
+                                                         expectedArgInRegister3,
+                                                         expectedArgInRegister4,
+                                                         expectedArgInRegister5,
+                                                         expectedArgInRegister6,
+                                                         expectedArgInRegister7)
+
+            // Then: the NamedService is resolved
+            expect(resolvedNamedService).toNot(beNil())
+
+            // When: executing the resolved function
+            receivedResult = resolvedNamedService!(expectedArg)
+
+            // Then: the registered function is called
+            expect(receivedArg) == expectedArg
+            expect(receivedResult) == expectedResult
+            // Then: the parameters received in the register function are the expected one
+            expect(receivedArgInRegister1) == expectedArgInRegister1
+            expect(receivedArgInRegister2) == expectedArgInRegister2
+            expect(receivedArgInRegister3) == expectedArgInRegister3
+            expect(receivedArgInRegister4) == expectedArgInRegister4
+            expect(receivedArgInRegister5) == expectedArgInRegister5
+            expect(receivedArgInRegister6) == expectedArgInRegister6
+            expect(receivedArgInRegister7) == expectedArgInRegister7
+        }
+
+        it("resolves the registered NamedService with height arguments") {
+            let expectedArg = "1701"
+            let expectedResult = 1701
+
+            var receivedArg: String?
+            var receivedResult: Int?
+            let expectedArgInRegister1 = 17.01
+            var receivedArgInRegister1: Double?
+            let expectedArgInRegister2 = 17.02
+            var receivedArgInRegister2: Double?
+            let expectedArgInRegister3 = 17.03
+            var receivedArgInRegister3: Double?
+            let expectedArgInRegister4 = 17.04
+            var receivedArgInRegister4: Double?
+            let expectedArgInRegister5 = 17.05
+            var receivedArgInRegister5: Double?
+            let expectedArgInRegister6 = 17.06
+            var receivedArgInRegister6: Double?
+            let expectedArgInRegister7 = 17.07
+            var receivedArgInRegister7: Double?
+            let expectedArgInRegister8 = 17.08
+            var receivedArgInRegister8: Double?
+
+            // Given: a function to register in a Swinject container
+            let functionToRegister: MockNamedService.Service = { arg in
+                receivedArg = arg
+                return expectedResult
+            }
+
+            // Given: a registration of this function as a NamedService with some Double parameters
+            container.register(namedServiceType: MockNamedService.self,
+                               factory: { (_, arg1: Double, arg2: Double, arg3: Double, arg4: Double, arg5: Double, arg6: Double, arg7: Double, arg8: Double) -> MockNamedService.Service in
+                                receivedArgInRegister1 = arg1
+                                receivedArgInRegister2 = arg2
+                                receivedArgInRegister3 = arg3
+                                receivedArgInRegister4 = arg4
+                                receivedArgInRegister5 = arg5
+                                receivedArgInRegister6 = arg6
+                                receivedArgInRegister7 = arg7
+                                receivedArgInRegister8 = arg8
+                                return functionToRegister
+            })
+
+            // When: resolving this NamedService
+            let resolvedNamedService = container.resolve(namedServiceType: MockNamedService.self,
+                                                         arguments: expectedArgInRegister1,
+                                                         expectedArgInRegister2,
+                                                         expectedArgInRegister3,
+                                                         expectedArgInRegister4,
+                                                         expectedArgInRegister5,
+                                                         expectedArgInRegister6,
+                                                         expectedArgInRegister7,
+                                                         expectedArgInRegister8)
+
+            // Then: the NamedService is resolved
+            expect(resolvedNamedService).toNot(beNil())
+
+            // When: executing the resolved function
+            receivedResult = resolvedNamedService!(expectedArg)
+
+            // Then: the registered function is called
+            expect(receivedArg) == expectedArg
+            expect(receivedResult) == expectedResult
+            // Then: the parameters received in the register function are the expected one
+            expect(receivedArgInRegister1) == expectedArgInRegister1
+            expect(receivedArgInRegister2) == expectedArgInRegister2
+            expect(receivedArgInRegister3) == expectedArgInRegister3
+            expect(receivedArgInRegister4) == expectedArgInRegister4
+            expect(receivedArgInRegister5) == expectedArgInRegister5
+            expect(receivedArgInRegister6) == expectedArgInRegister6
+            expect(receivedArgInRegister7) == expectedArgInRegister7
+            expect(receivedArgInRegister8) == expectedArgInRegister8
+        }
+
+        it("resolves the registered NamedService with nine arguments") {
+            let expectedArg = "1701"
+            let expectedResult = 1701
+
+            var receivedArg: String?
+            var receivedResult: Int?
+            let expectedArgInRegister1 = 17.01
+            var receivedArgInRegister1: Double?
+            let expectedArgInRegister2 = 17.02
+            var receivedArgInRegister2: Double?
+            let expectedArgInRegister3 = 17.03
+            var receivedArgInRegister3: Double?
+            let expectedArgInRegister4 = 17.04
+            var receivedArgInRegister4: Double?
+            let expectedArgInRegister5 = 17.05
+            var receivedArgInRegister5: Double?
+            let expectedArgInRegister6 = 17.06
+            var receivedArgInRegister6: Double?
+            let expectedArgInRegister7 = 17.07
+            var receivedArgInRegister7: Double?
+            let expectedArgInRegister8 = 17.08
+            var receivedArgInRegister8: Double?
+            let expectedArgInRegister9 = 17.09
+            var receivedArgInRegister9: Double?
+
+            // Given: a function to register in a Swinject container
+            let functionToRegister: MockNamedService.Service = { arg in
+                receivedArg = arg
+                return expectedResult
+            }
+
+            // Given: a registration of this function as a NamedService with some Double parameters
+            container.register(namedServiceType: MockNamedService.self,
+                               factory: { (_, arg1: Double, arg2: Double, arg3: Double, arg4: Double, arg5: Double, arg6: Double, arg7: Double, arg8: Double, arg9: Double) -> MockNamedService.Service in
+                                receivedArgInRegister1 = arg1
+                                receivedArgInRegister2 = arg2
+                                receivedArgInRegister3 = arg3
+                                receivedArgInRegister4 = arg4
+                                receivedArgInRegister5 = arg5
+                                receivedArgInRegister6 = arg6
+                                receivedArgInRegister7 = arg7
+                                receivedArgInRegister8 = arg8
+                                receivedArgInRegister9 = arg9
+                                return functionToRegister
+            })
+
+            // When: resolving this NamedService
+            let resolvedNamedService = container.resolve(namedServiceType: MockNamedService.self,
+                                                         arguments: expectedArgInRegister1,
+                                                         expectedArgInRegister2,
+                                                         expectedArgInRegister3,
+                                                         expectedArgInRegister4,
+                                                         expectedArgInRegister5,
+                                                         expectedArgInRegister6,
+                                                         expectedArgInRegister7,
+                                                         expectedArgInRegister8,
+                                                         expectedArgInRegister9)
+
+            // Then: the NamedService is resolved
+            expect(resolvedNamedService).toNot(beNil())
+
+            // When: executing the resolved function
+            receivedResult = resolvedNamedService!(expectedArg)
+
+            // Then: the registered function is called
+            expect(receivedArg) == expectedArg
+            expect(receivedResult) == expectedResult
+            // Then: the parameters received in the register function are the expected one
+            expect(receivedArgInRegister1) == expectedArgInRegister1
+            expect(receivedArgInRegister2) == expectedArgInRegister2
+            expect(receivedArgInRegister3) == expectedArgInRegister3
+            expect(receivedArgInRegister4) == expectedArgInRegister4
+            expect(receivedArgInRegister5) == expectedArgInRegister5
+            expect(receivedArgInRegister6) == expectedArgInRegister6
+            expect(receivedArgInRegister7) == expectedArgInRegister7
+            expect(receivedArgInRegister8) == expectedArgInRegister8
+            expect(receivedArgInRegister9) == expectedArgInRegister9
+        }
+    }
+}

--- a/Tests/SwinjectTests/NamedServiceSpec.swift
+++ b/Tests/SwinjectTests/NamedServiceSpec.swift
@@ -1,0 +1,24 @@
+//
+//  Copyright © 2020 Swinject Contributors. All rights reserved.
+//
+
+import Nimble
+import Quick
+import Swinject
+
+private enum Sut: NamedService {
+    typealias Service = (String) -> Int
+}
+
+class NamedServiceSpec: QuickSpec {
+
+    override func spec() {
+        it("produces the expected name and type") {
+            let expectedType = "\(((String) -> Int).self)"
+            let expectedName = "Sut"
+
+            expect("\(Sut.type)") == expectedType
+            expect(Sut.name) == expectedName
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces the concept of NamedService.

NamedService is an helper to register named functions in a Container and to make this look like a traditional registration.

I'm not familiar with Quick and Nimble so I did my best to add the significant Unit Tests.